### PR TITLE
Custom Hook Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-rc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-rc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-rc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "James Portelli",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-rc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "James Portelli",
   "license": "MIT",
   "repository": {

--- a/src/useNotifier.ts
+++ b/src/useNotifier.ts
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useCallback } from 'react';
 
 import { NotifierContext, NotificationDetails } from './NotifierProvider';
 import { Kind } from './Notification/enums';
@@ -12,21 +12,33 @@ export function useNotifier() {
     throw new Error('useNotifier must be used within a NotifierProvider');
   }
 
-  function showSuccessNotification(message: React.ReactChild, options?: NotificationOptions) {
-    setNotification!({ ...options, kind: Kind.Success, message });
-  }
+  const showSuccessNotification = useCallback(
+    (message: React.ReactChild, options?: NotificationOptions) => {
+      setNotification!({ ...options, kind: Kind.Success, message });
+    },
+    [setNotification]
+  );
 
-  function showInfoNotification(message: React.ReactChild, options?: NotificationOptions) {
-    setNotification!({ ...options, kind: Kind.Info, message });
-  }
+  const showInfoNotification = useCallback(
+    (message: React.ReactChild, options?: NotificationOptions) => {
+      setNotification!({ ...options, kind: Kind.Info, message });
+    },
+    [setNotification]
+  );
 
-  function showWarningNotification(message: React.ReactChild, options?: NotificationOptions) {
-    setNotification!({ ...options, kind: Kind.Warning, message });
-  }
+  const showWarningNotification = useCallback(
+    (message: React.ReactChild, options?: NotificationOptions) => {
+      setNotification!({ ...options, kind: Kind.Warning, message });
+    },
+    [setNotification]
+  );
 
-  function showErrorNotification(message: React.ReactChild, options?: NotificationOptions) {
-    setNotification!({ ...options, kind: Kind.Error, message });
-  }
+  const showErrorNotification = useCallback(
+    (message: React.ReactChild, options?: NotificationOptions) => {
+      setNotification!({ ...options, kind: Kind.Error, message });
+    },
+    [setNotification]
+  );
 
   return {
     showSuccessNotification,


### PR DESCRIPTION
Interesting read: https://overreacted.io/a-complete-guide-to-useeffect/

Without wrapping these functions with the useCallback hook, we can end up in an infinite call loop when using them within the useEffect hook and they are marked in the dependency array.

This happens because every time a functional component is render the function is called. This means that the functions exposed by the useNotifier hook are created each time, and thus would be different on every render.